### PR TITLE
feat: Optimize Rendering and Filtering in NearbyDogs Component

### DIFF
--- a/components/Dogs/NearbyDogs.tsx
+++ b/components/Dogs/NearbyDogs.tsx
@@ -3,6 +3,7 @@ import Container from "@/components/Container";
 import DogCard from "@/components/Dogs/DogCard";
 import { Dog, SerializableUser } from "../../types";
 import { NUM_DOGS_TO_DISPLAY } from "@/lib/constants";
+import { useParams } from "next/navigation";
 
 interface NearbyDogsProps {
   nearbyDogs: Dog[];
@@ -10,6 +11,8 @@ interface NearbyDogsProps {
 }
 
 const NearbyDogs = ({ nearbyDogs, currentUser }: NearbyDogsProps) => {
+  const params = useParams();
+
   return (
     <Container>
       <hr />
@@ -22,13 +25,17 @@ const NearbyDogs = ({ nearbyDogs, currentUser }: NearbyDogsProps) => {
       </div>
       <hr />
       <div className="mt-10 grid grid-cols-2 gap-8 md:grid-cols-3 lg:grid-cols-4">
-        {Array.from({ length: NUM_DOGS_TO_DISPLAY }).map((_, i) => (
-          <DogCard
-            key={nearbyDogs[i].id}
-            data={nearbyDogs[i]}
-            currentUser={currentUser}
-          />
-        ))}
+        {Array.from({ length: NUM_DOGS_TO_DISPLAY }).map((_, i) =>
+          i < nearbyDogs.length ? (
+            params.dogId !== nearbyDogs[i].id ? (
+              <DogCard
+                key={nearbyDogs[i].id}
+                data={nearbyDogs[i]}
+                currentUser={currentUser}
+              />
+            ) : null
+          ) : null,
+        )}
       </div>
     </Container>
   );


### PR DESCRIPTION
In this commit, we've enhanced the 'NearbyDogs.tsx' component to improve rendering and filter out the current dog from nearby results. Specifically, we've:

- Optimized rendering for cases where the number of nearby dogs is less than the default display limit (4). Was reading undefined before
- Implemented filtering logic to prevent the current dog from appearing in the nearby results.

Before
![Screenshot 2023-10-11 at 7 10 21 PM](https://github.com/rcervant/fetch-take-home/assets/50217213/8210dedb-2c8c-4718-8cf6-214325e8e56c)


After
![Screenshot 2023-10-11 at 7 11 28 PM](https://github.com/rcervant/fetch-take-home/assets/50217213/f626eba3-c811-42e2-a5b1-1dc87dfd0f15)
